### PR TITLE
fix(sec): upgrade tk.mybatis:mapper to 4.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <mybatis-starter-version>1.2.0</mybatis-starter-version>
     <mybatis.plus.version>2.0.7</mybatis.plus.version>
     <druid.version>1.0.29</druid.version>
-    <mapper.version>3.4.0</mapper.version>
+    <mapper.version>4.2.1</mapper.version>
     <springframework.version>4.3.8.RELEASE</springframework.version>
     <paascloud.security.version>1.0</paascloud.security.version>
     <paascloud.version>1.0</paascloud.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in tk.mybatis:mapper 3.4.0
- [MPS-2022-51955](https://www.oscs1024.com/hd/MPS-2022-51955)


### What did I do？
Upgrade tk.mybatis:mapper from 3.4.0 to 4.2.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS