### PR TITLE
fix(sec): upgrade com.alibaba:druid to 1.2.4

### DIFF
--- a/paascloud-generator/pom.xml
+++ b/paascloud-generator/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.0.18</version>
+            <version>1.2.4</version>
         </dependency>
         <dependency>
             <groupId>com.github.pagehelper</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alibaba:druid 1.0.18
- [CVE-2021-33800](https://www.oscs1024.com/hd/CVE-2021-33800)


### What did I do？
Upgrade com.alibaba:druid from 1.0.18 to 1.2.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS