### PR TITLE
fix(sec): upgrade org.liquibase:liquibase-core to 4.8.0

### DIFF
--- a/paascloud-provider/pom.xml
+++ b/paascloud-provider/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>3.5.3</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.liquibase:liquibase-core 3.5.3
- [CVE-2022-0839](https://www.oscs1024.com/hd/CVE-2022-0839)


### What did I do？
Upgrade org.liquibase:liquibase-core from 3.5.3 to 4.8.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS